### PR TITLE
fixup! Check for not imported keys after multi key import from rpmdb

### DIFF
--- a/zypp/PublicKey.cc
+++ b/zypp/PublicKey.cc
@@ -338,7 +338,11 @@ namespace zypp
   { return makeIterable( &(*_pimpl->_subkeys.begin()), &(*_pimpl->_subkeys.end()) ); }
 
   bool PublicKeyData::providesKey( const std::string & id_r ) const
-  { return( id_r == _pimpl->_id || _pimpl->hasSubkeyId( id_r ) ); }
+  {
+    if ( id_r.size() == 8 )	// as a convenience allow to test the 8byte short ID rpm uses as gpg-pubkey version
+      return str::endsWithCI( _pimpl->_id, id_r );
+    return( id_r == _pimpl->_id || _pimpl->hasSubkeyId( id_r ) );
+  }
 
   PublicKeyData::AsciiArt PublicKeyData::asciiArt() const
   { return AsciiArt( fingerprint() /* TODO: key algorithm could be added as top tile. */ ); }


### PR DESCRIPTION
Check whether the rpm db keys were imported into the zypp keyring must be based on the keys version (gpgkeys short id).  The release/creation-time is not reliable.

In case the key is already present in the trusted keyring (but with a different release/creation-time), and we update the key with the release from the rpm database, the release/creation-time we derive from the updated keyring may remain unchanged. 

This is no bug, but due to the way rpm computes the release/creation-time (oldest creation/modification date from signatures type "13x") and the way gpg updates the key (mergeing the signature packages).

As the main goal is to detect legacy V3 keys (which gpg does not import at all), it is sufficient to check whether the rpm keys version/short-id is present in the gpg-keyring after the import.